### PR TITLE
Update wiki content about tables of world database

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 These pages are aimed at helping contributors with setting up the server environment correctly, and also to provide documentation for the different features so you don't have to get down to the code itself in order to figure out how things work.
 
-### General:
+### General
 * [About the project](https://github.com/vmangos/wiki/wiki/About-the-project)
 * [FAQ](https://github.com/vmangos/wiki/wiki/Frequently-Asked-Questions)
 
 
-### First steps:
+### First steps
 * [Compiling on Windows](https://github.com/vmangos/wiki/wiki/Compiling-on-Windows)
 * [Compiling on Linux](https://github.com/vmangos/wiki/wiki/Compiling-on-Linux)
 * [Getting it working](https://github.com/vmangos/wiki/wiki/Getting-it-working)
 * [Contribution guide](https://github.com/vmangos/wiki/wiki/Contribution-guide)
 
 
-### Database tables:
+### Database tables
 * Account Database
 * Character Database
 * [World Database](https://github.com/vmangos/wiki/wiki/World-Database)


### PR DESCRIPTION
I cannot pull request for Wiki since it's not supported feature in GitHub: [Here](https://github.com/micttyoid/vmangos-wiki-ai-gen) is the update.

Note the content was **AI-generated** based on the old Brotalnia database. It needs some brief checkup.